### PR TITLE
fix: pass parent class loader to freemarker component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <gravitee-bom.version>6.0.4</gravitee-bom.version>
         <gravitee-reporter-api.version>1.26.0</gravitee-reporter-api.version>
         <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
-        <gravitee-common.version>3.3.0</gravitee-common.version>
+        <gravitee-common.version>3.3.2</gravitee-common.version>
         <gravitee-node.version>4.0.0</gravitee-node.version>
 
         <jackson-dataformat-msgpack.version>0.9.5</jackson-dataformat-msgpack.version>

--- a/src/main/java/io/gravitee/reporter/common/formatter/elasticsearch/ElasticsearchFormatter.java
+++ b/src/main/java/io/gravitee/reporter/common/formatter/elasticsearch/ElasticsearchFormatter.java
@@ -45,7 +45,8 @@ import java.util.Map;
 public class ElasticsearchFormatter<T extends Reportable>
   extends AbstractFormatter<T> {
 
-  private static final String INDEX_TEMPLATES_PATTERN = "/es%dx/index/";
+  private static final String TEMPLATES_BASE_PATTERN =
+    "/freemarker/es%dx/index/";
 
   /** Index simple date format **/
   private final DateTimeFormatter dtf;
@@ -67,12 +68,17 @@ public class ElasticsearchFormatter<T extends Reportable>
 
   public ElasticsearchFormatter(Node node, int elasticSearchVersion) {
     this.node = node;
-    this.freeMarkerComponent =
-      new FreeMarkerComponent(
-        String.format(INDEX_TEMPLATES_PATTERN, elasticSearchVersion)
-      );
     this.dtf = dtfWithDefaultZone("yyyy-MM-dd'T'HH:mm:ss.SSS[XXX]");
     this.sdf = dtfWithDefaultZone("yyyy.MM.dd");
+
+    this.freeMarkerComponent =
+      FreeMarkerComponent
+        .builder()
+        .classLoader(getClass().getClassLoader())
+        .classLoaderTemplateBase(
+          String.format(TEMPLATES_BASE_PATTERN, elasticSearchVersion)
+        )
+        .build();
   }
 
   private static DateTimeFormatter dtfWithDefaultZone(String format) {
@@ -401,10 +407,10 @@ public class ElasticsearchFormatter<T extends Reportable>
     return generateData("v4-message-log.ftl", data);
   }
 
-  private Buffer generateData(String templateName, Map<String, Object> data) {
+  private Buffer generateData(String template, Map<String, Object> data) {
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       freeMarkerComponent.generateFromTemplate(
-        templateName,
+        template,
         data,
         new OutputStreamWriter(baos)
       );


### PR DESCRIPTION
waiting for https://github.com/gravitee-io/gravitee-common/pull/101
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.3-fix-template-loader-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.0.3-fix-template-loader-SNAPSHOT/gravitee-reporter-common-1.0.3-fix-template-loader-SNAPSHOT.zip)
  <!-- Version placeholder end -->
