### PR TITLE
fix: add j_string to escape endpoint URL

### DIFF
--- a/src/main/resources/freemarker/es7x/index/health.ftl
+++ b/src/main/resources/freemarker/es7x/index/health.ftl
@@ -22,7 +22,7 @@
     "_id" : "${status.getId()}",
 </#if>
     "api":"${status.getApi()}",
-    "endpoint":"${status.getEndpoint()}",
+    "endpoint":"${status.getEndpoint()?j_string}",
     "available":${status.isAvailable()?c},
     "response-time":${status.getResponseTime()},
     "success":${status.isSuccess()?c},
@@ -33,7 +33,7 @@
         {"name": "${step.getName()}",
         "success":${step.isSuccess()?c},
         "request": {
-            "uri":"${step.getRequest().getUri()}",
+            "uri":"${step.getRequest().getUri()?j_string}",
             "method":"${step.getRequest().getMethod()}"
             <#if step.getRequest().getBody()??>
             ,"body":"${step.getRequest().getBody()?j_string}"

--- a/src/main/resources/freemarker/es7x/index/log.ftl
+++ b/src/main/resources/freemarker/es7x/index/log.ftl
@@ -17,7 +17,7 @@
   <#if log.getClientRequest()??>
   ,"client-request": {
   "method":"${log.getClientRequest().getMethod()}",
-  "uri":"${log.getClientRequest().getUri()}"
+  "uri":"${log.getClientRequest().getUri()?j_string}"
     <#if log.getClientRequest().getBody()??>
     ,"body":"${log.getClientRequest().getBody()?j_string}"
     </#if>
@@ -63,7 +63,7 @@
   <#if log.getProxyRequest()??>
   ,"proxy-request": {
   "method":"${log.getProxyRequest().getMethod()}",
-  "uri":"${log.getProxyRequest().getUri()}"
+  "uri":"${log.getProxyRequest().getUri()?j_string}"
     <#if log.getProxyRequest().getBody()??>
     ,"body":"${log.getProxyRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es7x/index/request.ftl
+++ b/src/main/resources/freemarker/es7x/index/request.ftl
@@ -12,7 +12,7 @@
   </#if>
   ,"transaction":"${metrics.getTransactionId()}"
   ,"method":${metrics.getHttpMethod().code()?c}
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   ,"status":${metrics.getStatus()}
   ,"response-time":${metrics.getProxyResponseTimeMs()}
   <#if apiResponseTime??>
@@ -39,7 +39,7 @@
   ,"local-address":"${metrics.getLocalAddress()}"
   ,"remote-address":"${metrics.getRemoteAddress()}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if metrics.getTenant()??>
   ,"tenant":"${metrics.getTenant()}"

--- a/src/main/resources/freemarker/es7x/index/v4-log.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-log.ftl
@@ -20,7 +20,7 @@
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {
   "method":"${log.getEntrypointRequest().getMethod()}",
-  "uri":"${log.getEntrypointRequest().getUri()}"
+  "uri":"${log.getEntrypointRequest().getUri()?j_string}"
     <#if log.getEntrypointRequest().getBody()??>
     ,"body":"${log.getEntrypointRequest().getBody()?j_string}"
     </#if>
@@ -67,7 +67,7 @@
   <#if log.getEndpointRequest()??>
   ,"endpoint-request": {
   "method":"${log.getEndpointRequest().getMethod()}",
-  "uri":"${log.getEndpointRequest().getUri()}"
+  "uri":"${log.getEndpointRequest().getUri()?j_string}"
     <#if log.getEndpointRequest().getBody()??>
     ,"body":"${log.getEndpointRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
@@ -56,7 +56,7 @@
   ,"host":"${metrics.getHost()}"
   </#if>
   <#if metrics.getUri()??>
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   </#if>
   <#if metrics.getPathInfo()??>
   ,"path-info":"${metrics.getPathInfo()}"
@@ -74,7 +74,7 @@
   </#if>
   ,"request-ended":"${metrics.isRequestEnded()?c}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if endpointResponseTimeMs??>
   ,"endpoint-response-time-ms":${endpointResponseTimeMs}

--- a/src/main/resources/freemarker/es8x/index/health.ftl
+++ b/src/main/resources/freemarker/es8x/index/health.ftl
@@ -22,7 +22,7 @@
     "_id" : "${status.getId()}",
 </#if>
     "api":"${status.getApi()}",
-    "endpoint":"${status.getEndpoint()}",
+    "endpoint":"${status.getEndpoint()?j_string}",
     "available":${status.isAvailable()?c},
     "response-time":${status.getResponseTime()},
     "success":${status.isSuccess()?c},
@@ -33,7 +33,7 @@
         {"name": "${step.getName()}",
         "success":${step.isSuccess()?c},
         "request": {
-            "uri":"${step.getRequest().getUri()}",
+            "uri":"${step.getRequest().getUri()?j_string}",
             "method":"${step.getRequest().getMethod()}"
             <#if step.getRequest().getBody()??>
             ,"body":"${step.getRequest().getBody()?j_string}"

--- a/src/main/resources/freemarker/es8x/index/log.ftl
+++ b/src/main/resources/freemarker/es8x/index/log.ftl
@@ -17,7 +17,7 @@
   <#if log.getClientRequest()??>
   ,"client-request": {
   "method":"${log.getClientRequest().getMethod()}",
-  "uri":"${log.getClientRequest().getUri()}"
+  "uri":"${log.getClientRequest().getUri()?j_string}"
     <#if log.getClientRequest().getBody()??>
     ,"body":"${log.getClientRequest().getBody()?j_string}"
     </#if>
@@ -63,7 +63,7 @@
   <#if log.getProxyRequest()??>
   ,"proxy-request": {
   "method":"${log.getProxyRequest().getMethod()}",
-  "uri":"${log.getProxyRequest().getUri()}"
+  "uri":"${log.getProxyRequest().getUri()?j_string}"
     <#if log.getProxyRequest().getBody()??>
     ,"body":"${log.getProxyRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es8x/index/request.ftl
+++ b/src/main/resources/freemarker/es8x/index/request.ftl
@@ -12,7 +12,7 @@
   </#if>
   ,"transaction":"${metrics.getTransactionId()}"
   ,"method":${metrics.getHttpMethod().code()?c}
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   ,"status":${metrics.getStatus()}
   ,"response-time":${metrics.getProxyResponseTimeMs()}
   <#if apiResponseTime??>
@@ -39,7 +39,7 @@
   ,"local-address":"${metrics.getLocalAddress()}"
   ,"remote-address":"${metrics.getRemoteAddress()}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if metrics.getTenant()??>
   ,"tenant":"${metrics.getTenant()}"

--- a/src/main/resources/freemarker/es8x/index/v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-log.ftl
@@ -20,7 +20,7 @@
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {
   "method":"${log.getEntrypointRequest().getMethod()}",
-  "uri":"${log.getEntrypointRequest().getUri()}"
+  "uri":"${log.getEntrypointRequest().getUri()?j_string}"
     <#if log.getEntrypointRequest().getBody()??>
     ,"body":"${log.getEntrypointRequest().getBody()?j_string}"
     </#if>
@@ -67,7 +67,7 @@
   <#if log.getEndpointRequest()??>
   ,"endpoint-request": {
   "method":"${log.getEndpointRequest().getMethod()}",
-  "uri":"${log.getEndpointRequest().getUri()}"
+  "uri":"${log.getEndpointRequest().getUri()?j_string}"
     <#if log.getEndpointRequest().getBody()??>
     ,"body":"${log.getEndpointRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
@@ -56,7 +56,7 @@
   ,"host":"${metrics.getHost()}"
   </#if>
   <#if metrics.getUri()??>
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   </#if>
   <#if metrics.getPathInfo()??>
   ,"path-info":"${metrics.getPathInfo()}"
@@ -74,7 +74,7 @@
   </#if>
   ,"request-ended":"${metrics.isRequestEnded()?c}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if endpointResponseTimeMs??>
   ,"endpoint-response-time-ms":${endpointResponseTimeMs}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-3180

this fix this error :
`{"type":"json_parse_exception","reason":"Unrecognized character escape '%' (code 37)...` if you can you API with escaped % like : `http://localhost:8082/echo?abc=\%`


About test : 
I don't see how you can do a test for that. I wanted to add one but it doesn't change anything :/ 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.4-APIM-3180-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.0.4-APIM-3180-SNAPSHOT/gravitee-reporter-common-1.0.4-APIM-3180-SNAPSHOT.zip)
  <!-- Version placeholder end -->
