### PR TITLE
fix: handle null client response

### DIFF
--- a/src/main/resources/freemarker/es7x/index/log.ftl
+++ b/src/main/resources/freemarker/es7x/index/log.ftl
@@ -38,6 +38,8 @@
     }
     </#if>
   }
+  </#if>
+  <#if log.getClientResponse()??>
   ,"client-response": {
   "status":${log.getClientResponse().getStatus()}
     <#if log.getClientResponse().getBody()??>

--- a/src/main/resources/freemarker/es8x/index/log.ftl
+++ b/src/main/resources/freemarker/es8x/index/log.ftl
@@ -38,6 +38,8 @@
     }
     </#if>
   }
+  </#if>
+  <#if log.getClientResponse()??>
   ,"client-response": {
   "status":${log.getClientResponse().getStatus()}
     <#if log.getClientResponse().getBody()??>


### PR DESCRIPTION
Client response can be null when log configuration is Request only. In v3 engine, an object with only the status was reported all the time. However, In v4 engine emulation, there is no object.

https://gravitee.atlassian.net/browse/APIM-3770

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.5-apim3770-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.0.5-apim3770-SNAPSHOT/gravitee-reporter-common-1.0.5-apim3770-SNAPSHOT.zip)
  <!-- Version placeholder end -->
