### PR TITLE
fix: typo in ftl for countIncrement

### DIFF
--- a/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
@@ -39,7 +39,7 @@
   ,"error-count":"${errorCount}"
   </#if>
   <#if countIncrement??>
-    ,"count-increment":${counIncrementt}
+    ,"count-increment":${countIncrement}
   </#if>
   <#if errorCountIncrement??>
     ,"error-count-increment":"${errorCountIncrement}"


### PR DESCRIPTION
**Description**

Small typo in ftl template for `countIncrement` (was `counIncrementt`)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.2-fix-ftl-typo-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.2.2-fix-ftl-typo-SNAPSHOT/gravitee-reporter-common-1.2.2-fix-ftl-typo-SNAPSHOT.zip)
  <!-- Version placeholder end -->
