### PR TITLE
feat: create shared BulkProcessor for reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,9 @@
         <gravitee-bom.version>6.0.60</gravitee-bom.version>
         <gravitee-reporter-api.version>1.31.0</gravitee-reporter-api.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
-        <gravitee-common.version>3.4.1</gravitee-common.version>
+        <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-node.version>4.8.7</gravitee-node.version>
+        <awaitility.version>4.2.2</awaitility.version>
 
         <jackson-dataformat-msgpack.version>0.9.8</jackson-dataformat-msgpack.version>
         <commons-validator.version>1.8.0</commons-validator.version>
@@ -191,6 +192,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/reporter/common/bulk/BulkConfiguration.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/BulkConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public record BulkConfiguration(
+  Integer items,
+  Long flushInterval,
+  Integer maxConcurrentSend,
+  Integer maxRetries,
+  Integer retryInitialDelay,
+  Integer retryMaxDelay,
+  Long maxMemorySize
+) {
+  public static final int DEFAULT_ITEMS = 1000;
+  public static final long DEFAULT_FLUSH_INTERVAL = 5L;
+  public static final int DEFAULT_MAX_CONCURRENT_SEND = 100;
+  public static final Integer DEFAULT_RETRY_MAX_RETRIES = 6;
+  public static final int DEFAULT_RETRY_INITIAL_DELAY = 3000;
+  public static final int DEFAULT_RETRY_MAX_DELAY = 30000;
+  public static final long DEFAULT_MAX_MEMORY_SIZE = 26214400;
+
+  public BulkConfiguration {
+    if (items == null) {
+      items = DEFAULT_ITEMS;
+    }
+    if (flushInterval == null) {
+      flushInterval = DEFAULT_FLUSH_INTERVAL;
+    }
+    if (maxConcurrentSend == null) {
+      maxConcurrentSend = DEFAULT_MAX_CONCURRENT_SEND;
+    }
+    if (maxRetries == null) {
+      maxRetries = DEFAULT_RETRY_MAX_RETRIES;
+    }
+    if (retryInitialDelay == null) {
+      retryInitialDelay = DEFAULT_RETRY_INITIAL_DELAY;
+    }
+    if (retryMaxDelay == null) {
+      retryMaxDelay = DEFAULT_RETRY_MAX_DELAY;
+    }
+    if (maxMemorySize == null) {
+      maxMemorySize = DEFAULT_MAX_MEMORY_SIZE;
+    }
+
+    if (maxMemorySize.equals(DEFAULT_MAX_MEMORY_SIZE)) {
+      log.warn(
+        "You are using the default 'maxMemorySize' ({}MB). Consider increase this value in case of too frequent 'Dropping bulk of reports' events.",
+        (DEFAULT_MAX_MEMORY_SIZE / 1024 / 1024)
+      );
+    }
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/BulkProcessor.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/BulkProcessor.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.common.utils.RxHelper;
+import io.gravitee.reporter.api.Reportable;
+import io.gravitee.reporter.common.bulk.backpressure.BulkDropper;
+import io.gravitee.reporter.common.bulk.backpressure.FlowableBackPressureMemoryAware;
+import io.gravitee.reporter.common.bulk.compressor.BulkCompressor;
+import io.gravitee.reporter.common.bulk.compressor.CompressedBulk;
+import io.gravitee.reporter.common.bulk.exception.NonRetryableException;
+import io.gravitee.reporter.common.bulk.sender.BulkSender;
+import io.gravitee.reporter.common.bulk.transformer.BulkTransformer;
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.processors.UnicastProcessor;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class BulkProcessor extends AbstractService<BulkProcessor> {
+
+  public static final double RETRY_FACTOR = 1.5;
+
+  private final BulkSender bulkSender;
+  private final BulkConfiguration bulkConfiguration;
+  private final BulkTransformer bulkTransformer;
+  private final UnicastProcessor<Reportable> processor =
+    UnicastProcessor.create();
+  private final BulkCompressor bulkCompressor;
+  private final BulkDropper bulkDropper;
+  private Disposable subscribe;
+
+  @Override
+  protected void doStart() throws Exception {
+    super.doStart();
+    bulkSender.start();
+    subscribe =
+      processor
+        .observeOn(Schedulers.io())
+        .flatMapMaybe(this::transform)
+        .buffer(
+          bulkConfiguration.flushInterval(),
+          TimeUnit.SECONDS,
+          bulkConfiguration.items()
+        )
+        .filter(reports -> !reports.isEmpty())
+        .flatMapMaybe(this::compress)
+        .compose(bulks ->
+          new FlowableBackPressureMemoryAware(
+            bulks,
+            bulkConfiguration.maxMemorySize(),
+            bulk -> bulkDropper.drop(bulk, BulkDropper.Reason.OVERFLOW)
+          )
+        )
+        .flatMapCompletable(
+          this::send,
+          true,
+          bulkConfiguration.maxConcurrentSend()
+        )
+        .retry()
+        .subscribe();
+  }
+
+  private Maybe<@NonNull TransformedReport> transform(
+    final Reportable reportable
+  ) {
+    return Maybe
+      .fromCallable(() -> bulkTransformer.transform(reportable))
+      .filter(transformedReport ->
+        Objects.nonNull(transformedReport.transformed())
+      )
+      .doOnError(throwable ->
+        log.warn("Unable to format incoming reportable", throwable)
+      )
+      .onErrorComplete();
+  }
+
+  private Maybe<CompressedBulk> compress(
+    List<@NonNull TransformedReport> reports
+  ) {
+    return Maybe
+      .fromCallable(() -> bulkCompressor.compress(reports))
+      .doOnError(throwable ->
+        log.warn("Unable to compress incoming reports", throwable)
+      )
+      .onErrorComplete();
+  }
+
+  private Completable send(CompressedBulk bulk) {
+    final AtomicInteger attempts = new AtomicInteger(0);
+
+    return Completable
+      .defer(() -> bulkSender.send(bulk))
+      .doOnSubscribe(s ->
+        log.debug(
+          "Sending bulk of reports [{}] (attempt {}).",
+          bulk,
+          attempts.get()
+        )
+      )
+      .doOnComplete(() -> log.debug("Bulk of reports successfully sent."))
+      .retryWhen(
+        RxHelper.retryExponentialBackoff(
+          bulkConfiguration.retryInitialDelay(),
+          bulkConfiguration.retryMaxDelay(),
+          TimeUnit.MILLISECONDS,
+          RETRY_FACTOR,
+          t -> {
+            log.warn(
+              "An error occurred when sending bulk of reports [{}]",
+              bulk,
+              t
+            );
+            if (
+              t instanceof NonRetryableException ||
+              attempts.incrementAndGet() > bulkConfiguration.maxRetries()
+            ) {
+              bulkDropper.drop(bulk, BulkDropper.Reason.ERROR);
+              return false;
+            }
+
+            return true;
+          }
+        )
+      )
+      .onErrorComplete();
+  }
+
+  @Override
+  protected void doStop() throws Exception {
+    super.doStop();
+    if (subscribe != null) {
+      subscribe.dispose();
+    }
+    bulkSender.stop();
+  }
+
+  public void process(Reportable reportable) {
+    processor.onNext(reportable);
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/backpressure/BulkDropper.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/backpressure/BulkDropper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.backpressure;
+
+import io.gravitee.reporter.common.bulk.compressor.CompressedBulk;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor
+public class BulkDropper {
+
+  private final Map<String, Integer> countPerType = new ConcurrentHashMap<>(8);
+
+  public enum Reason {
+    ERROR,
+    OVERFLOW,
+  }
+
+  public void drop(CompressedBulk bulk, Reason reason) {
+    bulk
+      .countPerType()
+      .forEach((bulkType, count) ->
+        countPerType.compute(
+          bulkType,
+          (counterType, total) -> total == null ? count : total + count
+        )
+      );
+
+    if (reason == Reason.OVERFLOW) {
+      log.warn(
+        "Overflow detected. Dropping bulk of reports to avoid too much memory pressure [{}]. Total: [{}].",
+        bulk,
+        countPerType
+      );
+    } else {
+      log.warn(
+        "Bulk error detected. Dropping bulk of reports [{}]. Total: [{}].",
+        bulk,
+        countPerType
+      );
+    }
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/backpressure/FlowableBackPressureMemoryAware.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/backpressure/FlowableBackPressureMemoryAware.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.backpressure;
+
+import io.gravitee.reporter.common.bulk.compressor.CompressedBulk;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableSubscriber;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import java.io.Serial;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Backpressure implementation allowing to buffer the bulk of reports in memory until it reaches the <code>maxMemorySize</code>.
+ * Once the max memory is reached, it drops the oldest bulk of reports and calls the registered <code>onDropped</code> callback (if any) for each dropped bulk.
+ *
+ * It is inspired by {@link io.reactivex.rxjava3.internal.operators.flowable.FlowableOnBackpressureBufferStrategy}.
+ */
+public final class FlowableBackPressureMemoryAware
+  extends Flowable<CompressedBulk> {
+
+  final Flowable<CompressedBulk> source;
+  final long maxMemorySize;
+  final Consumer<? super CompressedBulk> onDropped;
+
+  public FlowableBackPressureMemoryAware(
+    Flowable<CompressedBulk> source,
+    long maxMemorySize,
+    Consumer<? super CompressedBulk> onDropped
+  ) {
+    this.source = source;
+    this.maxMemorySize = maxMemorySize;
+    this.onDropped = onDropped;
+  }
+
+  @Override
+  protected void subscribeActual(
+    @NonNull Subscriber<? super CompressedBulk> s
+  ) {
+    source.subscribe(
+      new BackpressureBufferMemoryAwareSubscriber(s, maxMemorySize, onDropped)
+    );
+  }
+
+  static class BackpressureBufferMemoryAwareSubscriber
+    extends AtomicInteger
+    implements FlowableSubscriber<CompressedBulk>, Subscription {
+
+    @Serial
+    private static final long serialVersionUID = -7651817331081893000L;
+
+    final Subscriber<? super CompressedBulk> downstream;
+    final long maxMemorySize;
+    final Consumer<? super CompressedBulk> onDropped;
+    final AtomicLong requested;
+    final Deque<CompressedBulk> deque;
+    Subscription upstream;
+
+    volatile boolean cancelled;
+    volatile boolean done;
+    Throwable error;
+    final AtomicLong totalMemoryUsed = new AtomicLong(0);
+
+    BackpressureBufferMemoryAwareSubscriber(
+      Subscriber<? super CompressedBulk> actual,
+      long maxMemorySize,
+      Consumer<? super CompressedBulk> onDropped
+    ) {
+      this.downstream = actual;
+      this.maxMemorySize = maxMemorySize;
+      this.requested = new AtomicLong();
+      this.deque = new ArrayDeque<>();
+      this.onDropped = onDropped;
+    }
+
+    @Override
+    public void onSubscribe(@NonNull Subscription s) {
+      if (SubscriptionHelper.validate(this.upstream, s)) {
+        this.upstream = s;
+
+        downstream.onSubscribe(this);
+
+        s.request(Long.MAX_VALUE);
+      }
+    }
+
+    @Override
+    public void onNext(CompressedBulk c) {
+      if (done) {
+        return;
+      }
+      boolean callDrain = false;
+      List<CompressedBulk> toDropList = null;
+
+      synchronized (deque) {
+        if (totalMemoryUsed.get() <= maxMemorySize) {
+          deque.offer(c);
+          increaseMemoryUsed(c);
+          callDrain = true;
+        } else {
+          CompressedBulk dropCandidate;
+          long totalFreeSpace = 0;
+          do {
+            dropCandidate = deque.poll();
+            if (dropCandidate != null) {
+              final int freeSpace = dropCandidate.compressed().length();
+              decreaseMemoryUsed(freeSpace);
+              totalFreeSpace += freeSpace;
+              if (toDropList == null) {
+                toDropList = new ArrayList<>();
+              }
+              toDropList.add(dropCandidate);
+            }
+          } while (
+            dropCandidate != null && totalFreeSpace < c.compressed().length()
+          );
+
+          deque.offer(c);
+          increaseMemoryUsed(c);
+        }
+      }
+
+      if (onDropped != null && toDropList != null) {
+        try {
+          for (CompressedBulk drop : toDropList) {
+            onDropped.accept(drop);
+          }
+        } catch (Throwable ex) {
+          Exceptions.throwIfFatal(ex);
+          upstream.cancel();
+          onError(ex);
+        }
+      }
+
+      if (callDrain) {
+        drain();
+      }
+    }
+
+    private void decreaseMemoryUsed(int freeSpace) {
+      totalMemoryUsed.updateAndGet(currentValue -> currentValue - freeSpace);
+    }
+
+    private void increaseMemoryUsed(CompressedBulk c) {
+      totalMemoryUsed.updateAndGet(currentValue ->
+        currentValue + c.compressed().length()
+      );
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      if (done) {
+        RxJavaPlugins.onError(t);
+        return;
+      }
+      error = t;
+      done = true;
+      drain();
+    }
+
+    @Override
+    public void onComplete() {
+      done = true;
+      drain();
+    }
+
+    @Override
+    public void request(long n) {
+      if (SubscriptionHelper.validate(n)) {
+        BackpressureHelper.add(requested, n);
+        drain();
+      }
+    }
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+      upstream.cancel();
+
+      if (getAndIncrement() == 0) {
+        clear();
+      }
+    }
+
+    void clear() {
+      synchronized (deque) {
+        deque.clear();
+      }
+    }
+
+    void drain() {
+      if (getAndIncrement() != 0) {
+        return;
+      }
+
+      int missed = 1;
+      Subscriber<? super CompressedBulk> a = downstream;
+      do {
+        long r = requested.get();
+        long e = 0L;
+        while (e != r) {
+          if (cancelled) {
+            clear();
+            return;
+          }
+
+          boolean d = done;
+
+          CompressedBulk b;
+
+          synchronized (deque) {
+            b = deque.poll();
+          }
+
+          boolean empty = b == null;
+
+          if (d) {
+            Throwable ex = error;
+            if (ex != null) {
+              clear();
+              a.onError(ex);
+              return;
+            }
+            if (empty) {
+              a.onComplete();
+              return;
+            }
+          }
+
+          if (empty) {
+            break;
+          }
+
+          decreaseMemoryUsed(b.compressed().length());
+          a.onNext(b);
+
+          e++;
+        }
+
+        if (e == r) {
+          if (cancelled) {
+            clear();
+            return;
+          }
+
+          boolean d = done;
+
+          boolean empty;
+
+          synchronized (deque) {
+            empty = deque.isEmpty();
+          }
+
+          if (d) {
+            Throwable ex = error;
+            if (ex != null) {
+              clear();
+              a.onError(ex);
+              return;
+            }
+            if (empty) {
+              a.onComplete();
+              return;
+            }
+          }
+        }
+
+        if (e != 0L) {
+          BackpressureHelper.produced(requested, e);
+        }
+
+        missed = addAndGet(-missed);
+      } while (missed != 0);
+    }
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/compressor/BulkCompressor.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/compressor/BulkCompressor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.compressor;
+
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.reactivex.rxjava3.annotations.NonNull;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface BulkCompressor {
+  /**
+   * Called as a second step of the bulk process to compress o bulk of {@link TransformedReport} into one {@link CompressedBulk}
+   *
+   * @param reports
+   * @return a built {@link CompressedBulk}
+   */
+  CompressedBulk compress(List<@NonNull TransformedReport> reports)
+    throws IOException;
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/compressor/CompressedBulk.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/compressor/CompressedBulk.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.compressor;
+
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a bulk of reports that have been compressed into a single buffer.
+ * It also allows to hold a counter per type of report that have been compressed.
+ *
+ * @param compressed the compressed buffer.
+ * @param countPerType a {@link Map} that contains the number of reports compressed per type.
+ */
+public record CompressedBulk(
+  Buffer compressed,
+  Map<String, Integer> countPerType
+) {
+  @Override
+  public String toString() {
+    return Objects.toString(countPerType);
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/compressor/GzipBulkCompressor.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/compressor/GzipBulkCompressor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.compressor;
+
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+public class GzipBulkCompressor implements BulkCompressor {
+
+  @Override
+  public CompressedBulk compress(List<@NonNull TransformedReport> reports)
+    throws IOException {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final Map<String, Integer> countPerType = new HashMap<>(8);
+
+    try (final OutputStream gzip = new GZIPOutputStream(out)) {
+      for (TransformedReport report : reports) {
+        countPerType.compute(
+          report.type(),
+          (clazz, integer) -> integer != null ? ++integer : 1
+        );
+
+        // In memory, not blocking.
+        gzip.write(report.transformed().getBytes());
+      }
+    }
+    return new CompressedBulk(Buffer.buffer(out.toByteArray()), countPerType);
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/compressor/NoneBulkCompressor.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/compressor/NoneBulkCompressor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.compressor;
+
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+public class NoneBulkCompressor implements BulkCompressor {
+
+  @Override
+  public CompressedBulk compress(List<@NonNull TransformedReport> reports)
+    throws IOException {
+    try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      final Map<String, Integer> countPerType = new HashMap<>(8);
+      for (TransformedReport report : reports) {
+        countPerType.compute(
+          report.type(),
+          (clazz, integer) -> integer != null ? ++integer : 1
+        );
+
+        // In memory, not blocking.
+        out.write(report.transformed().getBytes());
+      }
+      return new CompressedBulk(Buffer.buffer(out.toByteArray()), countPerType);
+    }
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/exception/NonRetryableException.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/exception/NonRetryableException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.exception;
+
+import java.io.Serial;
+
+public class NonRetryableException extends RuntimeException {
+
+  @Serial
+  private static final long serialVersionUID = 4365687747607573938L;
+
+  public NonRetryableException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/exception/SendReportException.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/exception/SendReportException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.exception;
+
+import java.io.Serial;
+
+public class SendReportException extends RuntimeException {
+
+  @Serial
+  private static final long serialVersionUID = -206823564137258857L;
+
+  public SendReportException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/sender/BulkSender.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/sender/BulkSender.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.sender;
+
+import io.gravitee.common.service.Service;
+import io.gravitee.reporter.common.bulk.compressor.CompressedBulk;
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface BulkSender extends Service<BulkSender> {
+  /**
+   * Called as a last step of the bulk process to send a bulk of reportable represented by a {@link CompressedBulk} to the target reporter
+   * </p>
+   * The returned Completable can signal an error using a {@link io.gravitee.reporter.common.bulk.exception.NonRetryableException}
+   * to indicate a failure that should not be retried. Any other exception will be treated as retryable.
+   *
+   * @param bulk
+   * @return {@link Completable} of the result
+   */
+  Completable send(final CompressedBulk bulk);
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/transformer/BulkFormatterTransformer.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/transformer/BulkFormatterTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.transformer;
+
+import io.gravitee.reporter.api.Reportable;
+import io.gravitee.reporter.common.formatter.Formatter;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class BulkFormatterTransformer implements BulkTransformer {
+
+  private final Formatter<Reportable> formatter;
+
+  @Override
+  public TransformedReport transform(final Reportable reportable) {
+    return new TransformedReport(
+      Buffer.newInstance(
+        formatter.format(reportable, buildOptions(reportable))
+      ),
+      reportable.getClass()
+    );
+  }
+
+  protected Map<String, Object> buildOptions(final Reportable reportable) {
+    return null;
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/transformer/BulkTransformer.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/transformer/BulkTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.transformer;
+
+import io.gravitee.reporter.api.Reportable;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface BulkTransformer {
+  /**
+   * Called as a first step of the bulk process to transform on reportable to a {@link TransformedReport}
+   *
+   * @param reportable
+   * @return a built  {@link TransformedReport}
+   */
+  TransformedReport transform(final Reportable reportable);
+}

--- a/src/main/java/io/gravitee/reporter/common/bulk/transformer/TransformedReport.java
+++ b/src/main/java/io/gravitee/reporter/common/bulk/transformer/TransformedReport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.transformer;
+
+import io.gravitee.reporter.api.Reportable;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.util.Locale;
+
+/**
+ * Represents a report (log, metrics, request, ...) that has been transformed into its final format ('json', 'csv', 'elasticsearch', ...).
+ *
+ * @param transformed the report that has been transformed.
+ * @param clazz the initial type of the report.
+ */
+public record TransformedReport(
+  Buffer transformed,
+  Class<? extends Reportable> clazz
+) {
+  public String type() {
+    return clazz.getSimpleName().toLowerCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/io/gravitee/reporter/common/formatter/elasticsearch/ElasticsearchFormatter.java
+++ b/src/main/java/io/gravitee/reporter/common/formatter/elasticsearch/ElasticsearchFormatter.java
@@ -446,6 +446,9 @@ public class ElasticsearchFormatter<T extends Reportable>
       if (esOptions.get("pipeline") != null) {
         data.put("pipeline", esOptions.get("pipeline"));
       }
+      if (esOptions.get("date") == null) {
+        data.put("date", sdf.format(reportable.timestamp()));
+      }
     } else {
       data.put("date", sdf.format(reportable.timestamp()));
     }

--- a/src/test/java/io/gravitee/reporter/common/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/gravitee/reporter/common/bulk/BulkProcessorTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.common.bulk.backpressure.BulkDropper;
+import io.gravitee.reporter.common.bulk.compressor.BulkCompressor;
+import io.gravitee.reporter.common.bulk.compressor.CompressedBulk;
+import io.gravitee.reporter.common.bulk.compressor.NoneBulkCompressor;
+import io.gravitee.reporter.common.bulk.exception.NonRetryableException;
+import io.gravitee.reporter.common.bulk.exception.SendReportException;
+import io.gravitee.reporter.common.bulk.sender.BulkSender;
+import io.gravitee.reporter.common.bulk.transformer.BulkFormatterTransformer;
+import io.gravitee.reporter.common.bulk.transformer.BulkTransformer;
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.gravitee.reporter.common.formatter.FormatterFactory;
+import io.gravitee.reporter.common.formatter.FormatterFactoryConfiguration;
+import io.gravitee.reporter.common.formatter.Type;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith({ MockitoExtension.class })
+public class BulkProcessorTest {
+
+  private BulkProcessor cut;
+
+  @Mock
+  private io.gravitee.node.api.Node node;
+
+  @Mock
+  private BulkSender bulkSender;
+
+  private BulkTransformer bulkTransformer;
+  private BulkCompressor bulkCompressor;
+  private BulkDropper bulkDropper;
+
+  @BeforeEach
+  public void beforeEach() {
+    lenient().when(node.id()).thenReturn("nodeId");
+
+    this.bulkTransformer =
+      new BulkFormatterTransformer(
+        new FormatterFactory(
+          node,
+          FormatterFactoryConfiguration
+            .builder()
+            .elasticSearchVersion(8)
+            .build()
+        )
+          .getFormatter(Type.ELASTICSEARCH)
+      );
+    this.bulkDropper = new BulkDropper();
+    this.bulkCompressor = new NoneBulkCompressor();
+  }
+
+  private void initBulkProcessor() throws Exception {
+    initBulkProcessor(1);
+  }
+
+  private void initBulkProcessor(final int items) throws Exception {
+    initBulkProcessor(items, 26214400L);
+  }
+
+  private void initBulkProcessor(final int items, final long memorySize)
+    throws Exception {
+    final BulkConfiguration bulkConfiguration = new BulkConfiguration(
+      items,
+      5L,
+      1,
+      5,
+      10,
+      30,
+      memorySize
+    );
+    when(bulkSender.send(any())).thenReturn(Completable.complete());
+    cut =
+      new BulkProcessor(
+        bulkSender,
+        bulkConfiguration,
+        bulkTransformer,
+        bulkCompressor,
+        bulkDropper
+      );
+    cut.start();
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    if (cut != null) {
+      cut.stop();
+    }
+  }
+
+  @Test
+  void should_process_a_reportable_and_send_it() throws Exception {
+    initBulkProcessor();
+    final Metrics reportable = buildMetrics();
+    final CompressedBulk expectedBody = bulkCompressor.compress(
+      List.of(bulkTransformer.transform(reportable))
+    );
+
+    cut.process(reportable);
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() ->
+        verify(bulkSender)
+          .send(argThat(argument -> argument.equals(expectedBody)))
+      );
+  }
+
+  @Test
+  void should_buffer_reports_and_send_single_content() throws Exception {
+    int items = 10;
+    initBulkProcessor(items);
+
+    final List<TransformedReport> transformedReports = new ArrayList<>();
+    for (int i = 0; i < items; i++) {
+      final Metrics reportable = buildMetrics();
+      cut.process(reportable);
+      transformedReports.add(bulkTransformer.transform(reportable));
+    }
+    final CompressedBulk expectedBody = bulkCompressor.compress(
+      transformedReports
+    );
+
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() ->
+        verify(bulkSender)
+          .send(
+            argThat(compressedBulk -> {
+              assertThat(compressedBulk.countPerType())
+                .contains(entry("metrics", 10));
+              assertThat(compressedBulk.compressed())
+                .isEqualTo(expectedBody.compressed());
+              return true;
+            })
+          )
+      );
+  }
+
+  @Test
+  void should_ignore_invalid_reportable() throws Exception {
+    initBulkProcessor();
+    cut.process(Metrics.builder().build()); // << invalid reportable with missing data
+    cut.process(buildMetrics());
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender).send(any()));
+  }
+
+  @Test
+  void should_ignore_and_continue_reporting_when_send_reports_throw_non_retryable_exceptions()
+    throws Exception {
+    initBulkProcessor();
+    when(bulkSender.send(any()))
+      .thenReturn(
+        Completable.error(
+          new NonRetryableException("1", new RuntimeException())
+        ),
+        Completable.error(
+          new NonRetryableException("2", new RuntimeException())
+        ),
+        Completable.complete()
+      );
+    cut.process(buildMetrics()); // expect NonRetryableException
+    cut.process(buildMetrics()); // expect NonRetryableException
+    cut.process(buildMetrics()); // expect ok
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(3)).send(any()));
+  }
+
+  @Test
+  void should_retry_reporting_when_send_reports_throw_retryable_exceptions()
+    throws Exception {
+    initBulkProcessor();
+    when(bulkSender.send(any()))
+      .thenReturn(
+        Completable.error(new SendReportException("1", new RuntimeException())),
+        Completable.error(new SendReportException("2", new RuntimeException())),
+        Completable.complete()
+      );
+    cut.process(buildMetrics()); // expect SendReportException
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(3)).send(any()));
+  }
+
+  @Test
+  void should_retry_reporting_when_any_exception_occurred_on_sending_reports()
+    throws Exception {
+    initBulkProcessor();
+    when(bulkSender.send(any()))
+      .thenThrow(new RuntimeException())
+      .thenReturn(Completable.complete());
+    cut.process(buildMetrics()); // expect SendReportException
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(2)).send(any()));
+  }
+
+  @Test
+  void should_drop_report_when_max_retries_is_reached() throws Exception {
+    initBulkProcessor(1, 30);
+    when(bulkSender.send(any())).thenThrow(new RuntimeException());
+    cut.process(buildMetrics()); // expect SendReportException
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(6)).send(any()));
+  }
+
+  @Test
+  void should_drop_report_when_max_memory_size_is_reached() throws Exception {
+    initBulkProcessor(1, 0);
+    when(bulkSender.send(any()))
+      .thenReturn(
+        Maybe.just(1).delay(1000, TimeUnit.MILLISECONDS).ignoreElement()
+      );
+    for (int i = 0; i < 100; i++) {
+      cut.process(buildMetrics());
+    }
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(1)).send(any()));
+  }
+
+  @Test
+  void should_drain_pending_reports_when_stopping() throws Exception {
+    initBulkProcessor(1, 0);
+    when(bulkSender.send(any()))
+      .thenReturn(
+        Maybe.just(1).delay(5000, TimeUnit.MILLISECONDS).ignoreElement()
+      );
+    for (int i = 0; i < 100; i++) {
+      cut.process(buildMetrics());
+    }
+    await()
+      .atMost(2, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(1)).send(any()));
+
+    // Cancel while the first call is still in progress (delay of 5s).
+    cut.stop();
+
+    // At the end, only 1 call has been made.
+    verify(bulkSender, times(1)).send(any());
+  }
+
+  @Test
+  void should_continue_reporting_when_transform_throws_exception()
+    throws Exception {
+    this.bulkTransformer = mock(BulkTransformer.class);
+    when(bulkTransformer.transform(any()))
+      .thenThrow(new RuntimeException())
+      .thenReturn(new TransformedReport(Buffer.buffer("test"), Metrics.class));
+
+    initBulkProcessor();
+    cut.process(buildMetrics()); // expect exception
+    cut.process(buildMetrics()); // expect ok
+
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(1)).send(any()));
+  }
+
+  @Test
+  void should_continue_reporting_when_compress_throws_exception()
+    throws Exception {
+    this.bulkCompressor = mock(BulkCompressor.class);
+
+    when(bulkCompressor.compress(ArgumentMatchers.any()))
+      .thenThrow(new IOException("Exception during compression"))
+      .thenReturn(
+        new CompressedBulk(
+          io.vertx.rxjava3.core.buffer.Buffer.buffer("data"),
+          Collections.emptyMap()
+        )
+      );
+
+    initBulkProcessor();
+    cut.process(buildMetrics()); // expect exception
+    cut.process(buildMetrics()); // expect ok
+
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> verify(bulkSender, times(1)).send(any()));
+  }
+
+  private static Metrics buildMetrics() {
+    return Metrics
+      .builder()
+      .requestId("requestId")
+      .transactionId("transactionId")
+      .httpMethod(HttpMethod.GET)
+      .uri("/uri")
+      .api("api")
+      .apiName("apiName")
+      .apiResponseTimeMs(1)
+      .application("application")
+      .clientIdentifier("clientIdentifier")
+      .endpoint("endpoint")
+      .host("host")
+      .path("/path")
+      .localAddress("localAddress")
+      .remoteAddress("remoteAddress")
+      .build();
+  }
+}

--- a/src/test/java/io/gravitee/reporter/common/bulk/compressor/GzipBulkCompressorTest.java
+++ b/src/test/java/io/gravitee/reporter/common/bulk/compressor/GzipBulkCompressorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.compressor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.reporter.api.Reportable;
+import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.v4.metric.MessageMetrics;
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GzipBulkCompressorTest {
+
+  private GzipBulkCompressor cut;
+
+  @BeforeEach
+  public void beforeEach() {
+    cut = new GzipBulkCompressor();
+  }
+
+  @Test
+  void should_compress_buffer() throws IOException {
+    TransformedReport transformedReport = new TransformedReport(
+      Buffer.buffer("clear"),
+      Reportable.class
+    );
+    final CompressedBulk expectedBody = cut.compress(
+      List.of(transformedReport)
+    );
+    assertThat(expectedBody.compressed())
+      .isNotEqualTo(transformedReport.transformed());
+    assertThat(uncompress(expectedBody.compressed()))
+      .isEqualTo(transformedReport.transformed());
+  }
+
+  @Test
+  void should_compute_per_type() throws IOException {
+    TransformedReport metricsType = new TransformedReport(
+      Buffer.buffer("metrics"),
+      Metrics.class
+    );
+    TransformedReport messageMetricsType = new TransformedReport(
+      Buffer.buffer("message_metrics"),
+      MessageMetrics.class
+    );
+    final CompressedBulk expectedBody = cut.compress(
+      List.of(metricsType, messageMetricsType)
+    );
+    assertThat(expectedBody.countPerType()).hasSize(2);
+    assertThat(expectedBody.countPerType())
+      .extracting(metricsType.type())
+      .isEqualTo(1);
+    assertThat(expectedBody.countPerType())
+      .extracting(messageMetricsType.type())
+      .isEqualTo(1);
+  }
+
+  private Buffer uncompress(final Buffer compressBuffer) throws IOException {
+    try (
+      ByteArrayInputStream bis = new ByteArrayInputStream(
+        compressBuffer.getBytes()
+      );
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      GZIPInputStream gzipIS = new GZIPInputStream(bis)
+    ) {
+      byte[] buffer = new byte[1024];
+      int len;
+      while ((len = gzipIS.read(buffer)) != -1) {
+        bos.write(buffer, 0, len);
+      }
+      return Buffer.buffer(bos.toByteArray());
+    }
+  }
+}

--- a/src/test/java/io/gravitee/reporter/common/bulk/compressor/NoneBulkCompressorTest.java
+++ b/src/test/java/io/gravitee/reporter/common/bulk/compressor/NoneBulkCompressorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.common.bulk.compressor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.reporter.api.Reportable;
+import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.v4.metric.MessageMetrics;
+import io.gravitee.reporter.common.bulk.transformer.TransformedReport;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NoneBulkCompressorTest {
+
+  private NoneBulkCompressor cut;
+
+  @BeforeEach
+  public void beforeEach() {
+    cut = new NoneBulkCompressor();
+  }
+
+  @Test
+  void should_not_compress_buffer() throws IOException {
+    TransformedReport transformedReport = new TransformedReport(
+      Buffer.buffer("clear"),
+      Reportable.class
+    );
+    final CompressedBulk expectedBody = cut.compress(
+      List.of(transformedReport)
+    );
+    assertThat(expectedBody.compressed())
+      .isEqualTo(transformedReport.transformed());
+  }
+
+  @Test
+  void should_compute_per_type() throws IOException {
+    TransformedReport metricsType = new TransformedReport(
+      Buffer.buffer("metrics"),
+      Metrics.class
+    );
+    TransformedReport messageMetricsType = new TransformedReport(
+      Buffer.buffer("message_metrics"),
+      MessageMetrics.class
+    );
+    final CompressedBulk expectedBody = cut.compress(
+      List.of(metricsType, messageMetricsType)
+    );
+    assertThat(expectedBody.countPerType()).hasSize(2);
+    assertThat(expectedBody.countPerType())
+      .extracting(metricsType.type())
+      .isEqualTo(1);
+    assertThat(expectedBody.countPerType())
+      .extracting(messageMetricsType.type())
+      .isEqualTo(1);
+  }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-435

**Description**

Create from cloud reporter a shared version of the bulk processor

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-archi-435-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.4.0-archi-435-SNAPSHOT/gravitee-reporter-common-1.4.0-archi-435-SNAPSHOT.zip)
  <!-- Version placeholder end -->
