### PR TITLE
fix: clientIdentifier validation for unauthorised error

### DIFF
--- a/src/main/resources/freemarker/es7x/index/v4-log.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-log.ftl
@@ -16,7 +16,9 @@
   ,"api-id":"${log.getApiId()}"
   ,"api-name":"${log.getApiName()?j_string}"
   ,"request-id":"${log.getRequestId()}"
+  <#if log.getClientIdentifier()??>
   ,"client-identifier":"${log.getClientIdentifier()}"
+  </#if>
   ,"request-ended":"${log.isRequestEnded()?c}"
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {

--- a/src/main/resources/freemarker/es8x/index/v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-log.ftl
@@ -16,7 +16,9 @@
   ,"api-id":"${log.getApiId()}"
   ,"api-name":"${log.getApiName()?j_string}"
   ,"request-id":"${log.getRequestId()}"
+  <#if log.getClientIdentifier()??>
   ,"client-identifier":"${log.getClientIdentifier()}"
+  </#if>
   ,"request-ended":"${log.isRequestEnded()?c}"
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-7146

**Description**

fix for missing logs for unauthorised error due to the mandatory client identifier field

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.1-APIM-7146-fix-logs-for-unauthorised-errors-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.3.1-APIM-7146-fix-logs-for-unauthorised-errors-SNAPSHOT/gravitee-reporter-common-1.3.1-APIM-7146-fix-logs-for-unauthorised-errors-SNAPSHOT.zip)
  <!-- Version placeholder end -->
