### PR TITLE
fix(deps): update gravitee-reporter-api to 1.33.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.7.6</gravitee-apim.version>
-        <gravitee-reporter-api.version>1.33.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.33.1</gravitee-reporter-api.version>
         <gravitee-node.version>4.8.9</gravitee-node.version>
         <awaitility.version>4.2.2</awaitility.version>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9761

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.1-bump-reporter-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.6.1-bump-reporter-api-SNAPSHOT/gravitee-reporter-common-1.6.1-bump-reporter-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
