### PR TITLE
fix: clean event-metrics.ftl template indentation and add ligne break the end

### DIFF
--- a/src/main/resources/freemarker/es8x/index/event-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/index/event-metrics.ftl
@@ -3,58 +3,57 @@
 <#-- @ftlvariable name="index" type="java.lang.String" -->
 <#-- @ftlvariable name="metrics" type="io.gravitee.reporter.api.v4.metric.EventMetrics" -->
 <#if index??>
-    { "index": { "_index": "${index}" } }
+{ "index": { "_index": "${index}" } }
 </#if>
 <#--noinspection FtlReferencesInspection-->
 <@compress single_line=true>
-    {
+{
     "@timestamp": "${@timestamp}"
     <#if !index??>
-        ,"type": "event-metrics"
-        ,"date": "${date}"
+    ,"type": "event-metrics"
+    ,"date": "${date}"
     </#if>
     ,"gw-id": "${metrics.getGatewayId()}"
     ,"org-id": "${metrics.getOrganizationId()}"
     ,"env-id": "${metrics.getEnvironmentId()}"
     ,"api-id": "${metrics.getApiId()}"
     <#if metrics.getPlanId()??>
-        ,"plan-id": "${metrics.getPlanId()}"
+    ,"plan-id": "${metrics.getPlanId()}"
     </#if>
     <#if metrics.getApplicationId()??>
-        ,"app-id": "${metrics.getApplicationId()}"
+    ,"app-id": "${metrics.getApplicationId()}"
     </#if>
     <#if metrics.getTopic()??>
-        ,"topic": "${metrics.getTopic()}"
+    ,"topic": "${metrics.getTopic()}"
     </#if>
     <#if metrics.getDownstreamPublishMessagesTotal()??>
-        ,"downstream-publish-messages-total": ${metrics.getDownstreamPublishMessagesTotal()}
+    ,"downstream-publish-messages-total": ${metrics.getDownstreamPublishMessagesTotal()}
     </#if>
     <#if metrics.getDownstreamPublishMessageBytes()??>
-        ,"downstream-publish-message-bytes": ${metrics.getDownstreamPublishMessageBytes()}
+    ,"downstream-publish-message-bytes": ${metrics.getDownstreamPublishMessageBytes()}
     </#if>
     <#if metrics.getUpstreamPublishMessagesTotal()??>
-        ,"upstream-publish-messages-total": ${metrics.getUpstreamPublishMessagesTotal()}
+    ,"upstream-publish-messages-total": ${metrics.getUpstreamPublishMessagesTotal()}
     </#if>
     <#if metrics.getUpstreamPublishMessageBytes()??>
-        ,"upstream-publish-message-bytes": ${metrics.getUpstreamPublishMessageBytes()}
+    ,"upstream-publish-message-bytes": ${metrics.getUpstreamPublishMessageBytes()}
     </#if>
     <#if metrics.getDownstreamSubscribeMessagesTotal()??>
-        ,"downstream-subscribe-messages-total": ${metrics.getDownstreamSubscribeMessagesTotal()}
+    ,"downstream-subscribe-messages-total": ${metrics.getDownstreamSubscribeMessagesTotal()}
     </#if>
     <#if metrics.getDownstreamSubscribeMessageBytes()??>
-        ,"downstream-subscribe-message-bytes": ${metrics.getDownstreamSubscribeMessageBytes()}
+    ,"downstream-subscribe-message-bytes": ${metrics.getDownstreamSubscribeMessageBytes()}
     </#if>
     <#if metrics.getUpstreamSubscribeMessagesTotal()??>
-        ,"upstream-subscribe-messages-total": ${metrics.getUpstreamSubscribeMessagesTotal()}
+    ,"upstream-subscribe-messages-total": ${metrics.getUpstreamSubscribeMessagesTotal()}
     </#if>
     <#if metrics.getUpstreamSubscribeMessageBytes()??>
-        ,"upstream-subscribe-message-bytes": ${metrics.getUpstreamSubscribeMessageBytes()}
+    ,"upstream-subscribe-message-bytes": ${metrics.getUpstreamSubscribeMessageBytes()}
     </#if>
     <#if metrics.getDownstreamActiveConnections()??>
-        ,"downstream-active-connections": ${metrics.getDownstreamActiveConnections()}
+    ,"downstream-active-connections": ${metrics.getDownstreamActiveConnections()}
     </#if>
     <#if metrics.getUpstreamActiveConnections()??>
-        ,"upstream-active-connections": ${metrics.getUpstreamActiveConnections()}
+    ,"upstream-active-connections": ${metrics.getUpstreamActiveConnections()}
     </#if>
-    }
-</@compress>
+}</@compress>


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-10024?atlOrigin=eyJpIjoiY2UxZWQwNTFhZDM1NDAxOTg1ZmZlYTQ2OTc1Y2NiMmYiLCJwIjoiaiJ9

**Description**

clean event-metrics.ftl template indentation and add ligne break the end

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-APIM-10024-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.7.0-APIM-10024-SNAPSHOT/gravitee-reporter-common-1.7.0-APIM-10024-SNAPSHOT.zip)
  <!-- Version placeholder end -->
