### PR TITLE
feat: add update template for even metrics in ES7

### DIFF
--- a/src/main/resources/freemarker/es7x/index/event-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/event-metrics.ftl
@@ -1,0 +1,59 @@
+<#ftl output_format="JSON">
+<#-- @ftlvariable name="@timestamp" type="java.lang.String" -->
+<#-- @ftlvariable name="index" type="java.lang.String" -->
+<#-- @ftlvariable name="metrics" type="io.gravitee.reporter.api.v4.metric.EventMetrics" -->
+<#if index??>
+{ "index": { "_index": "${index}" } }
+</#if>
+<#--noinspection FtlReferencesInspection-->
+<@compress single_line=true>
+{
+    "@timestamp": "${@timestamp}"
+    <#if !index??>
+    ,"type": "event-metrics"
+    ,"date": "${date}"
+    </#if>
+    ,"gw-id": "${metrics.getGatewayId()}"
+    ,"org-id": "${metrics.getOrganizationId()}"
+    ,"env-id": "${metrics.getEnvironmentId()}"
+    ,"api-id": "${metrics.getApiId()}"
+    <#if metrics.getPlanId()??>
+    ,"plan-id": "${metrics.getPlanId()}"
+    </#if>
+    <#if metrics.getApplicationId()??>
+    ,"app-id": "${metrics.getApplicationId()}"
+    </#if>
+    <#if metrics.getTopic()??>
+    ,"topic": "${metrics.getTopic()}"
+    </#if>
+    <#if metrics.getDownstreamPublishMessagesTotal()??>
+    ,"downstream-publish-messages-total": ${metrics.getDownstreamPublishMessagesTotal()}
+    </#if>
+    <#if metrics.getDownstreamPublishMessageBytes()??>
+    ,"downstream-publish-message-bytes": ${metrics.getDownstreamPublishMessageBytes()}
+    </#if>
+    <#if metrics.getUpstreamPublishMessagesTotal()??>
+    ,"upstream-publish-messages-total": ${metrics.getUpstreamPublishMessagesTotal()}
+    </#if>
+    <#if metrics.getUpstreamPublishMessageBytes()??>
+    ,"upstream-publish-message-bytes": ${metrics.getUpstreamPublishMessageBytes()}
+    </#if>
+    <#if metrics.getDownstreamSubscribeMessagesTotal()??>
+    ,"downstream-subscribe-messages-total": ${metrics.getDownstreamSubscribeMessagesTotal()}
+    </#if>
+    <#if metrics.getDownstreamSubscribeMessageBytes()??>
+    ,"downstream-subscribe-message-bytes": ${metrics.getDownstreamSubscribeMessageBytes()}
+    </#if>
+    <#if metrics.getUpstreamSubscribeMessagesTotal()??>
+    ,"upstream-subscribe-messages-total": ${metrics.getUpstreamSubscribeMessagesTotal()}
+    </#if>
+    <#if metrics.getUpstreamSubscribeMessageBytes()??>
+    ,"upstream-subscribe-message-bytes": ${metrics.getUpstreamSubscribeMessageBytes()}
+    </#if>
+    <#if metrics.getDownstreamActiveConnections()??>
+    ,"downstream-active-connections": ${metrics.getDownstreamActiveConnections()}
+    </#if>
+    <#if metrics.getUpstreamActiveConnections()??>
+    ,"upstream-active-connections": ${metrics.getUpstreamActiveConnections()}
+    </#if>
+}</@compress>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

Add update template for even metrics in ES7.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT/gravitee-reporter-common-1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
