### PR TITLE
feat: add more metrics in all formatters

### DIFF
--- a/src/main/java/io/gravitee/reporter/common/formatter/csv/v4/EventMetricsFormatter.java
+++ b/src/main/java/io/gravitee/reporter/common/formatter/csv/v4/EventMetricsFormatter.java
@@ -65,6 +65,24 @@ public class EventMetricsFormatter extends SingleValueFormatter<EventMetrics> {
     appendLong(buffer, getValue(downstreamActiveConnections));
     Number upstreamActiveConnections = data.getUpstreamActiveConnections();
     appendLong(buffer, getValue(upstreamActiveConnections));
+    Number upstreamAuthenticatedConnections =
+      data.getUpstreamAuthenticatedConnections();
+    appendLong(buffer, getValue(upstreamAuthenticatedConnections));
+    Number downstreamAuthenticatedConnections =
+      data.getDownstreamAuthenticatedConnections();
+    appendLong(buffer, getValue(downstreamAuthenticatedConnections));
+    Number downstreamAuthenticationFailuresTotal =
+      data.getDownstreamAuthenticationFailuresTotal();
+    appendLong(buffer, getValue(downstreamAuthenticationFailuresTotal));
+    Number upstreamAuthenticationFailuresTotal =
+      data.getUpstreamAuthenticationFailuresTotal();
+    appendLong(buffer, getValue(upstreamAuthenticationFailuresTotal));
+    Number downstreamAuthorizationSuccessesTotal =
+      data.getDownstreamAuthorizationSuccessesTotal();
+    appendLong(buffer, getValue(downstreamAuthorizationSuccessesTotal));
+    Number upstreamAuthorizationSuccessesTotal =
+      data.getUpstreamAuthorizationSuccessesTotal();
+    appendLong(buffer, getValue(upstreamAuthorizationSuccessesTotal));
 
     return buffer;
   }

--- a/src/main/resources/freemarker/es7x/index/event-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/event-metrics.ftl
@@ -56,4 +56,22 @@
     <#if metrics.getUpstreamActiveConnections()??>
     ,"upstream-active-connections": ${metrics.getUpstreamActiveConnections()}
     </#if>
+    <#if metrics.getUpstreamAuthenticatedConnections()??>
+    ,"upstream-authenticated-connections": ${metrics.getUpstreamAuthenticatedConnections()}
+    </#if>
+    <#if metrics.getDownstreamAuthenticatedConnections()??>
+    ,"downstream-authenticated-connections": ${metrics.getDownstreamAuthenticatedConnections()}
+    </#if>
+    <#if metrics.getDownstreamAuthenticationFailuresTotal()??>
+    ,"downstream-authentication-failures-total": ${metrics.getDownstreamAuthenticationFailuresTotal()}
+    </#if>
+    <#if metrics.getUpstreamAuthenticationFailuresTotal()??>
+    ,"upstream-authentication-failures-total": ${metrics.getUpstreamAuthenticationFailuresTotal()}
+    </#if>
+    <#if metrics.getDownstreamAuthorizationSuccessesTotal()??>
+    ,"downstream-authentication-successes-total": ${metrics.getDownstreamAuthorizationSuccessesTotal()}
+    </#if>
+    <#if metrics.getUpstreamAuthorizationSuccessesTotal()??>
+    ,"upstream-authentication-successes-total": ${metrics.getUpstreamAuthorizationSuccessesTotal()}
+    </#if>
 }</@compress>

--- a/src/main/resources/freemarker/es8x/index/event-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/index/event-metrics.ftl
@@ -56,4 +56,22 @@
     <#if metrics.getUpstreamActiveConnections()??>
     ,"upstream-active-connections": ${metrics.getUpstreamActiveConnections()}
     </#if>
+    <#if metrics.getUpstreamAuthenticatedConnections()??>
+    ,"upstream-authenticated-connections": ${metrics.getUpstreamAuthenticatedConnections()}
+    </#if>
+    <#if metrics.getDownstreamAuthenticatedConnections()??>
+    ,"downstream-authenticated-connections": ${metrics.getDownstreamAuthenticatedConnections()}
+    </#if>
+    <#if metrics.getDownstreamAuthenticationFailuresTotal()??>
+    ,"downstream-authentication-failures-total": ${metrics.getDownstreamAuthenticationFailuresTotal()}
+    </#if>
+    <#if metrics.getUpstreamAuthenticationFailuresTotal()??>
+    ,"upstream-authentication-failures-total": ${metrics.getUpstreamAuthenticationFailuresTotal()}
+    </#if>
+    <#if metrics.getDownstreamAuthorizationSuccessesTotal()??>
+    ,"downstream-authentication-successes-total": ${metrics.getDownstreamAuthorizationSuccessesTotal()}
+    </#if>
+    <#if metrics.getUpstreamAuthorizationSuccessesTotal()??>
+    ,"upstream-authentication-successes-total": ${metrics.getUpstreamAuthorizationSuccessesTotal()}
+    </#if>
 }</@compress>

--- a/src/test/resources/io/gravitee/reporter/common/formatter/expected/csv/v4/event-metrics.csv
+++ b/src/test/resources/io/gravitee/reporter/common/formatter/expected/csv/v4/event-metrics.csv
@@ -1,1 +1,1 @@
-1751015211866;"test_gateway";"test_org";"test_env";"test_api";"test_plan";"test_app";"test_topic";3112;213123;13123;213311;40593;432421;34413;2132131;4;3;
+1751015211866;"test_gateway";"test_org";"test_env";"test_api";"test_plan";"test_app";"test_topic";3112;213123;13123;213311;40593;432421;34413;2132131;4;3;10;10;12;12;15;15;

--- a/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/event-metrics.json
+++ b/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/event-metrics.json
@@ -18,5 +18,11 @@
   "upstream-subscribe-messages-total": 34413,
   "upstream-subscribe-message-bytes": 2132131,
   "downstream-active-connections": 4,
-  "upstream-active-connections": 3
+  "upstream-active-connections": 3,
+  "upstream-authenticated-connections": 10,
+  "downstream-authenticated-connections": 10,
+  "downstream-authentication-failures-total": 12,
+  "upstream-authentication-failures-total": 12,
+  "downstream-authentication-successes-total": 15,
+  "upstream-authentication-successes-total": 15
 }

--- a/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/event-metrics.jsonl
+++ b/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/event-metrics.jsonl
@@ -17,5 +17,11 @@
   "upstream-subscribe-messages-total": 34413,
   "upstream-subscribe-message-bytes": 2132131,
   "downstream-active-connections": 4,
-  "upstream-active-connections": 3
+  "upstream-active-connections": 3,
+  "upstream-authenticated-connections": 10,
+  "downstream-authenticated-connections": 10,
+  "downstream-authentication-failures-total": 12,
+  "upstream-authentication-failures-total": 12,
+  "downstream-authentication-successes-total": 15,
+  "upstream-authentication-successes-total": 15
 }

--- a/src/test/resources/io/gravitee/reporter/common/formatter/expected/json/v4/event-metrics.json
+++ b/src/test/resources/io/gravitee/reporter/common/formatter/expected/json/v4/event-metrics.json
@@ -16,5 +16,11 @@
   "upstreamSubscribeMessagesTotal": 34413,
   "upstreamSubscribeMessageBytes": 2132131,
   "downstreamActiveConnections": 4,
-  "upstreamActiveConnections": 3
+  "upstreamActiveConnections": 3,
+  "upstreamAuthenticatedConnections": 10,
+  "downstreamAuthenticatedConnections": 10,
+  "downstreamAuthenticationFailuresTotal": 12,
+  "upstreamAuthenticationFailuresTotal": 12,
+  "downstreamAuthorizationSuccessesTotal": 15,
+  "upstreamAuthorizationSuccessesTotal": 15
 }

--- a/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/event-metrics.json
+++ b/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/event-metrics.json
@@ -16,5 +16,11 @@
   "upstreamSubscribeMessagesTotal": 34413,
   "upstreamSubscribeMessageBytes": 2132131,
   "downstreamActiveConnections": 4,
-  "upstreamActiveConnections": 3
+  "upstreamActiveConnections": 3,
+  "upstreamAuthenticatedConnections": 10,
+  "downstreamAuthenticatedConnections": 10,
+  "downstreamAuthenticationFailuresTotal": 12,
+  "upstreamAuthenticationFailuresTotal": 12,
+  "downstreamAuthorizationSuccessesTotal": 15,
+  "upstreamAuthorizationSuccessesTotal": 15
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

This Pull Request introduces additional metrics related to authentication failures and authorization successes in both upstream and downstream scenarios. These changes are applied to the CSV formatter, Elasticsearch templates, and corresponding test resources.

**Main Changes**
- Code update: Added support in EventMetricsFormatter.java to handle new metrics: downstreamAuthenticationFailuresTotal, upstreamAuthenticationFailuresTotal, downstreamAuthorizationSuccessesTotal, upstreamAuthorizationSuccessesTotal.
- Template update: Modifications in Elasticsearch V7 and V8 index templates (event-metrics.ftl) to include the new metrics in generated data.

**Test resource updates**
- Updated CSV and JSON test resources to reflect the addition of new metrics.
- Added validation for the new fields in test resources to ensure correct behavior.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT/gravitee-reporter-common-1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
