### PR TITLE
feat: change index templates to perform only create operations

### DIFF
--- a/src/main/resources/freemarker/es7x/index/event-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/event-metrics.ftl
@@ -3,7 +3,7 @@
 <#-- @ftlvariable name="index" type="java.lang.String" -->
 <#-- @ftlvariable name="metrics" type="io.gravitee.reporter.api.v4.metric.EventMetrics" -->
 <#if index??>
-{ "index": { "_index": "${index}" } }
+{ "create": { "_index": "${index}" } }
 </#if>
 <#--noinspection FtlReferencesInspection-->
 <@compress single_line=true>

--- a/src/main/resources/freemarker/es8x/index/event-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/index/event-metrics.ftl
@@ -3,7 +3,7 @@
 <#-- @ftlvariable name="index" type="java.lang.String" -->
 <#-- @ftlvariable name="metrics" type="io.gravitee.reporter.api.v4.metric.EventMetrics" -->
 <#if index??>
-{ "index": { "_index": "${index}" } }
+{ "create": { "_index": "${index}" } }
 </#if>
 <#--noinspection FtlReferencesInspection-->
 <@compress single_line=true>

--- a/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/event-metrics.jsonl
+++ b/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/event-metrics.jsonl
@@ -1,4 +1,4 @@
-{ "index" : { "_index" : "gravitee-v4.metric.EventMetrics-2023.08.28" } }
+{ "create" : { "_index" : "gravitee-v4.metric.EventMetrics-2023.08.28" } }
 {
   "@timestamp": "2025-06-27T09:06:51.866Z",
   "plan-id": "test_plan",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

Change templates to perform only create operations on data stream.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT/gravitee-reporter-common-1.7.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
