### PR TITLE
fix: bulk request format for es7x/OpenSearch 2.5.0

### DIFF
--- a/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
@@ -117,32 +117,31 @@
   </#list>
   }
   </#if>
-  <#if (metrics.longAdditionalMetrics)()?? || (metrics.doubleAdditionalMetrics)()?? || (metrics.keywordAdditionalMetrics)()?? || (metrics.boolAdditionalMetrics)()??>
+  <#if (metrics.longAdditionalMetrics())?? || (metrics.doubleAdditionalMetrics())?? || (metrics.keywordAdditionalMetrics())?? || (metrics.boolAdditionalMetrics())??>
     ,"additional-metrics": {
-    <#if (metrics.longAdditionalMetrics)()??>
+    <#if (metrics.longAdditionalMetrics())??>
       <#list metrics.longAdditionalMetrics() as propKey, propValue>
         "${propKey}":${propValue}<#sep>,
       </#list>
-      <#if (metrics.doubleAdditionalMetrics)()?? || (metrics.keywordAdditionalMetrics)()?? || (metrics.boolAdditionalMetrics)()??>,</#if>
+      <#if (metrics.doubleAdditionalMetrics())?? || (metrics.keywordAdditionalMetrics())?? || (metrics.boolAdditionalMetrics())??>,</#if>
     </#if>
-    <#if (metrics.doubleAdditionalMetrics)()??>
+    <#if (metrics.doubleAdditionalMetrics())??>
       <#list metrics.doubleAdditionalMetrics() as propKey, propValue>
         "${propKey}":${propValue}<#sep>,
       </#list>
-      <#if (metrics.keywordAdditionalMetrics)()?? || (metrics.boolAdditionalMetrics)()??>,</#if>
+      <#if (metrics.keywordAdditionalMetrics())?? || (metrics.boolAdditionalMetrics())??>,</#if>
     </#if>
-    <#if (metrics.keywordAdditionalMetrics)()??>
+    <#if (metrics.keywordAdditionalMetrics())??>
       <#list metrics.keywordAdditionalMetrics() as propKey, propValue>
         "${propKey}":"${propValue}"<#sep>,
       </#list>
-      <#if (metrics.boolAdditionalMetrics)()??>,</#if>
+      <#if (metrics.boolAdditionalMetrics())??>,</#if>
     </#if>
-    <#if (metrics.boolAdditionalMetrics)()??>
+    <#if (metrics.boolAdditionalMetrics())??>
       <#list metrics.boolAdditionalMetrics() as propKey, propValue>
         "${propKey}":"${propValue?string('true', 'false')}"<#sep>,
       </#list>
     </#if>
     }
   </#if>
-}
-</@compress>
+  }</@compress>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-10943

**Description**

This PR addresses issues with the Gravitee Gateway failing to report metrics to Elasticsearch 7 / OpenSearch 2.5.0 when using the Elastic reporter. The errors occur because the v4-metrics.ftl template for ES7 does not properly format bulk requests.

Errors:

<img width="1686" height="464" alt="Screenshot 2025-09-04 at 7 33 47 PM" src="https://github.com/user-attachments/assets/2204ed42-21f5-405f-9492-6bee68e4ed97" />
<img width="1702" height="701" alt="Screenshot 2025-09-04 at 8 33 10 PM" src="https://github.com/user-attachments/assets/05131c94-354c-4834-8c0b-6d33cba722fe" />


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
