### PR TITLE
fix: bulk request format for es7x/OpenSearch 2.5.0

### DIFF
--- a/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
@@ -117,32 +117,31 @@
   </#list>
   }
   </#if>
-  <#if (metrics.longAdditionalMetrics)()?? || (metrics.doubleAdditionalMetrics)()?? || (metrics.keywordAdditionalMetrics)()?? || (metrics.boolAdditionalMetrics)()??>
+  <#if (metrics.longAdditionalMetrics())?? || (metrics.doubleAdditionalMetrics())?? || (metrics.keywordAdditionalMetrics())?? || (metrics.boolAdditionalMetrics())??>
     ,"additional-metrics": {
-    <#if (metrics.longAdditionalMetrics)()??>
+    <#if (metrics.longAdditionalMetrics())??>
       <#list metrics.longAdditionalMetrics() as propKey, propValue>
         "${propKey}":${propValue}<#sep>,
       </#list>
-      <#if (metrics.doubleAdditionalMetrics)()?? || (metrics.keywordAdditionalMetrics)()?? || (metrics.boolAdditionalMetrics)()??>,</#if>
+      <#if (metrics.doubleAdditionalMetrics())?? || (metrics.keywordAdditionalMetrics())?? || (metrics.boolAdditionalMetrics())??>,</#if>
     </#if>
-    <#if (metrics.doubleAdditionalMetrics)()??>
+    <#if (metrics.doubleAdditionalMetrics())??>
       <#list metrics.doubleAdditionalMetrics() as propKey, propValue>
         "${propKey}":${propValue}<#sep>,
       </#list>
-      <#if (metrics.keywordAdditionalMetrics)()?? || (metrics.boolAdditionalMetrics)()??>,</#if>
+      <#if (metrics.keywordAdditionalMetrics())?? || (metrics.boolAdditionalMetrics())??>,</#if>
     </#if>
-    <#if (metrics.keywordAdditionalMetrics)()??>
+    <#if (metrics.keywordAdditionalMetrics())??>
       <#list metrics.keywordAdditionalMetrics() as propKey, propValue>
         "${propKey}":"${propValue}"<#sep>,
       </#list>
-      <#if (metrics.boolAdditionalMetrics)()??>,</#if>
+      <#if (metrics.boolAdditionalMetrics())??>,</#if>
     </#if>
-    <#if (metrics.boolAdditionalMetrics)()??>
+    <#if (metrics.boolAdditionalMetrics())??>
       <#list metrics.boolAdditionalMetrics() as propKey, propValue>
         "${propKey}":"${propValue?string('true', 'false')}"<#sep>,
       </#list>
     </#if>
     }
   </#if>
-}
-</@compress>
+  }</@compress>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-10973

**Description**
This PR addresses issues with the Gravitee Gateway failing to report metrics to Elasticsearch 7 / OpenSearch 2.5.0 when using the Elastic reporter. The errors occur because the v4-metrics.ftl template for ES7 does not properly format bulk requests.



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
