### PR TITLE
fix: prevent empty JSON objects for fully excluded event types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@4.14.2
+  gravitee: gravitee-io/gravitee@4.16.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/src/main/java/io/gravitee/reporter/common/formatter/json/JsonFormatter.java
+++ b/src/main/java/io/gravitee/reporter/common/formatter/json/JsonFormatter.java
@@ -44,7 +44,12 @@ public class JsonFormatter<T extends Reportable> extends AbstractFormatter<T> {
   @Override
   public Buffer format0(T data) {
     try {
-      return Buffer.buffer(mapper.writeValueAsBytes(data));
+      String json = mapper.writeValueAsString(data);
+      if ("{}".equals(json)) {
+        LOG.trace("Excluding data format in reporter: {}", json);
+        return null;
+      }
+      return Buffer.buffer(json);
     } catch (JsonProcessingException e) {
       LOG.error("Unexpected error while formatting data", e);
       return null;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-11283

**Description**

Previously, the File Reporter created log files containing "{}" for each event line, even when all fields of an event type (e.g., request, node, health-check) were excluded via __exclude_0=* configuration. This resulted in "noise" files with meaningless empty JSON entries.

Now, when an event type is fully excluded, the reporter:

Returns null for format operations, avoiding "{}" output.
Ensures the corresponding log file is either not created or remains empty (0 bytes).
This aligns file reporter behavior with user intent when excluding entire event types.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.5-APIM-11283-file-reporter-ignore-excluded-json-events-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.6.5-APIM-11283-file-reporter-ignore-excluded-json-events-SNAPSHOT/gravitee-reporter-common-1.6.5-APIM-11283-file-reporter-ignore-excluded-json-events-SNAPSHOT.zip)
  <!-- Version placeholder end -->
