### PR TITLE
Revise versioning and module structure information

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,16 @@ https://github.com/gravitee-io/issues/issues/XXXXX
 
 A small description of what you did in that PR.
 
+> [!WARNING]
+> Major version 2.x is the latest version available for this repository.
+> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
+>
+> ⚠️**No new major version should be released.**
+> 
+> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
+> 
+> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-common` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+
 **Additional context**
 
 <!-- Add any other context about the PR here -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Gravitee Reporter Common
 
+> [!WARNING]
+> Major version 2.x is the latest version available for this repository.
+> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
+>
+> ⚠️**No new major version should be released.**
+> 
+> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+> 
+> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-common` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+
+
 This module contains common classes for our various reporter implementations.
 
 ## Compatibility
 
-[gravitee-reporter-api]("https://github.com/gravitee-io/gravitee-reporter-api") version is required to be at least 1.26.0.
+[gravitee-reporter-api](https://github.com/gravitee-io/gravitee-reporter-api) version is required to be at least 1.26.0.


### PR DESCRIPTION
Starting with APIM 4.11.0, reporter-common, reporter-file and reporter-elasticsearch have been added as maven module in apim monorepo.

This PR updates the README to add a warning about that change.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/2.0.0/gravitee-reporter-common-2.0.0.zip)
  <!-- Version placeholder end -->
