### PR TITLE
fix: update msgpack-core to 0.9.11 to fix security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <gravitee-node.version>4.8.9</gravitee-node.version>
         <awaitility.version>4.3.0</awaitility.version>
 
-        <jackson-dataformat-msgpack.version>0.9.10</jackson-dataformat-msgpack.version>
+        <jackson-dataformat-msgpack.version>0.9.11</jackson-dataformat-msgpack.version>
         <commons-validator.version>1.10.0</commons-validator.version>
     </properties>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12726

## Description

Updated the msgpack-core dependency (via jackson-dataformat-msgpack) from 0.9.10 to 0.9.11. 

This version includes a fix for GHSA-cw39-r4h6-8j3x (CVE-2026-21452), which prevented a Remote Denial of Service via unbounded memory allocation.


> [!WARNING]
> Major version 2.x is the latest version available for this repository.
> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
>
> ⚠️**No new major version should be released.**
> 
> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
> 
> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-common` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
