### PR TITLE
fix: update msgpack-core to 0.9.11 to fix security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-node.version>4.8.9</gravitee-node.version>
         <awaitility.version>4.3.0</awaitility.version>
 
-        <jackson-dataformat-msgpack.version>0.9.10</jackson-dataformat-msgpack.version>
+        <jackson-dataformat-msgpack.version>0.9.11</jackson-dataformat-msgpack.version>
         <commons-validator.version>1.10.0</commons-validator.version>
     </properties>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12726

**Description**

A small description of what you did in that PR.

> [!WARNING]
> Major version 2.x is the latest version available for this repository.
> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
>
> ⚠️**No new major version should be released.**
> 
> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
> 
> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-common` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.4-fix-apim-12726-msgpack-v1-9-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-common/1.9.4-fix-apim-12726-msgpack-v1-9-SNAPSHOT/gravitee-reporter-common-1.9.4-fix-apim-12726-msgpack-v1-9-SNAPSHOT.zip)
  <!-- Version placeholder end -->
