### PR TITLE
fix: update msgpack-core to 0.9.11 to fix security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <gravitee-node.version>4.8.7</gravitee-node.version>
         <awaitility.version>4.2.2</awaitility.version>
 
-        <jackson-dataformat-msgpack.version>0.9.8</jackson-dataformat-msgpack.version>
+        <jackson-dataformat-msgpack.version>0.9.11</jackson-dataformat-msgpack.version>
         <commons-validator.version>1.8.0</commons-validator.version>
     </properties>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12726

**Description**

A small description of what you did in that PR.

> [!WARNING]
> Major version 2.x is the latest version available for this repository.
> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
>
> ⚠️**No new major version should be released.**
> 
> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
> 
> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-common` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
